### PR TITLE
Add support for net-ssh v4.1

### DIFF
--- a/lib/net/ssh/telnet.rb
+++ b/lib/net/ssh/telnet.rb
@@ -208,14 +208,15 @@ module SSH
         @ssh = @options["Session"]
         @close_all = false
       elsif @options.has_key?("Proxy")
-        @ssh = Net::SSH.start(nil, nil,
-                :host_name => @options["Host"],  # ignored
-                :port => @options["Port"],       # ignored
-                :user => @options["Username"],
-                :password => @options["Password"],
-                :timeout => @options["Timeout"],
-                :proxy => TinyFactory.new(@options["Proxy"])
-        )
+        opts = {
+          :host_name => @options["Host"],  # ignored
+          :port => @options["Port"],       # ignored
+          :user => @options["Username"],
+          :password => @options["Password"],
+          :timeout => @options["Timeout"],
+          :proxy => TinyFactory.new(@options["Proxy"])
+        }.delete_if { |_,v| v.nil? }
+        @ssh = Net::SSH.start(nil, nil, opts)
         @close_all = true
       else
         message = "Trying " + @options["Host"] + "...\n"
@@ -224,14 +225,15 @@ module SSH
         @dumplog.log_dump('#', message) if @options.has_key?("Dump_log")
 
         begin
-          @ssh = Net::SSH.start(nil, nil,
-                :host_name => @options["Host"],
-                :port => @options["Port"],
-                :user => @options["Username"],
-                :password => @options["Password"],
-                :timeout => @options["Timeout"],
-                :proxy => @options["Factory"]
-          )
+          opts = {
+            :host_name => @options["Host"],
+            :port => @options["Port"],
+            :user => @options["Username"],
+            :password => @options["Password"],
+            :timeout => @options["Timeout"],
+            :proxy => @options["Factory"]
+          }.delete_if { |_,v| v.nil? }
+          @ssh = Net::SSH.start(nil, nil, opts)
           @close_all = true
         rescue TimeoutError
           raise TimeoutError, "timed out while opening a connection to the host"


### PR DESCRIPTION
With the gem 'net-ssh' v4.1, deprecated warning appears.
This pull request fix this issue by eliminating the nil value.

```
/home/haccht/test-app/vendor/bundle/ruby/2.4.0/gems/net-ssh-telnet-0.2.0/lib/net/ssh/telnet.rb:236:in `initialize': Passing nil, or [nil] to Net::SSH.start is deprecated for keys: proxy 
```