### PR TITLE
add PTYOptions option to pass arguments to #request_pty

### DIFF
--- a/lib/net/ssh/telnet.rb
+++ b/lib/net/ssh/telnet.rb
@@ -153,6 +153,7 @@ module SSH
     # * <tt>"Session"</tt> - An existing Net::Ssh object for Net::Ssh::Telnet to use as its connection(See example 1)
     # * <tt>"Proxy"</tt> - An open IO object to use as a Proxy(See example 3)
     # * <tt>"Factory"</tt> - A connection factory to use to establish the connection. Net::Ssh::Telnet will call #open(host, post) on this object.(See example 4)
+    # * <tt>"PTYOptions"</tt> - A hash to be passed to Net::SSH::Connection::Channel#request_pty. See Net::SSH::Connection::Channel::VALID_PTY_OPTIONS for valid options.
     #
     def initialize(options, &blk) # :yield: mesg
       @options = options
@@ -162,6 +163,7 @@ module SSH
       @options["Timeout"]    = 10            unless @options.has_key?("Timeout")
       @options["Waittime"]   = 0             unless @options.has_key?("Waittime")
       @options["Terminator"] = LF            unless @options.has_key?("Terminator")
+      @options["PTYOptions"] = {}            unless @options.has_key?("PTYOptions")
 
       unless @options.has_key?("Binmode")
         @options["Binmode"]    = false
@@ -254,7 +256,7 @@ module SSH
         channel.on_data { |ch,data| @buf << data }
         channel.on_extended_data { |ch,type,data| @buf << data if type == 1 }
         channel.on_close { @eof = true }
-        channel.request_pty { |ch,success|
+        channel.request_pty(@options["PTYOptions"]) { |ch,success|
           if success == false
             raise "Failed to open ssh pty"
           end


### PR DESCRIPTION
We've found this useful in some cases, most lately `term: 'vt100'` to disable ANSI colors.