### PR TITLE
add require statement for Net::ReadTimeout exception

### DIFF
--- a/lib/net/ssh/telnet.rb
+++ b/lib/net/ssh/telnet.rb
@@ -1,5 +1,5 @@
 require 'net/ssh'
-require 'net/http'
+require 'net/protocol'
 
 module Net
 module SSH

--- a/lib/net/ssh/telnet.rb
+++ b/lib/net/ssh/telnet.rb
@@ -1,4 +1,5 @@
 require 'net/ssh'
+require 'net/http'
 
 module Net
 module SSH


### PR DESCRIPTION
When there is a timeout running a command, it tries to raise a Net::ReadTimeout exception which is in the net/http library but not included in the requires.